### PR TITLE
EnclosingMethod attribute

### DIFF
--- a/lib/jas/src/jas/EnclMethAttr.java
+++ b/lib/jas/src/jas/EnclMethAttr.java
@@ -19,7 +19,8 @@ public class EnclMethAttr {
     void resolve(ClassEnv e){
         e.addCPItem(attr);
         e.addCPItem(cls);
-        e.addCPItem(meth);
+        if (null != meth)
+        	e.addCPItem(meth);
     }
 
     /**
@@ -29,7 +30,8 @@ public class EnclMethAttr {
     */
     public EnclMethAttr(String a, String b, String c) { //
         cls = new ClassCP(a);
-        meth = new NameTypeCP(b, c);
+        if (!b.isEmpty() && !c.isEmpty())
+        	meth = new NameTypeCP(b, c);
     }
 
     int size(){
@@ -44,6 +46,6 @@ public class EnclMethAttr {
         out.writeShort(e.getCPIndex(attr));
         out.writeInt(4); // fixed length
         out.writeShort(e.getCPIndex(cls));
-        out.writeShort(e.getCPIndex(meth));
+        out.writeShort(null == meth ? 0 : e.getCPIndex(meth));
     }
 }


### PR DESCRIPTION
I believe I have found an edge condition error in how Soot uses Jasmin to output assembled class files. The custom version of Jasmin distributed with Soot doesn't ever allow the EnclosingMethod attribute of an inner class to be zero. 

According to the Java class file spec [1], the EnclosingMethod attribute specifies "If the current class is not immediately enclosed by a method or constructor, then the value of the method_index item must be zero."

While Soot correctly passes EnclosingMethod tags with an empty method (e.g. ".enclosing_method_attr " "myClass" "" ""\n" ), the custom Jasmin creates an empty string in the class' constant pool and makes a reference to that. [2]

This bug was fixed at least as early as Jasmin version 2.0 [3]. I changed the EnclMethAttr class to make the same fix, using the current field names.

[1] http://docs.oracle.com/javase/specs/jvms/se7/html/jvms-4.html#jvms-4.7.7
[2] https://github.com/Sable/jasmin/blob/master/lib/jas/src/jas/EnclMethAttr.java
[3] http://sourceforge.net/projects/jasmin/files/jasmin/2.0/
