### PR TITLE
Encoding of source files unclear

### DIFF
--- a/lib/jas/src/jas/InvokeDynamicCP.java
+++ b/lib/jas/src/jas/InvokeDynamicCP.java
@@ -25,7 +25,7 @@ public class InvokeDynamicCP extends CP implements RuntimeConstants
   public InvokeDynamicCP(String bsmClassName, String bsmName, String bsmSig, String methodName, String methodSig, int bsmTableIndex)
   {
     this.bsmTableIndex = bsmTableIndex;
-	uniq = (bsmClassName + "fv0¤" + bsmName + "&%$91&" + bsmSig+ "*(012$" + methodName + "dfg8932" + methodSig).intern();
+	uniq = (bsmClassName + "fv0\u20ac" + bsmName + "&%$91&" + bsmSig+ "*(012$" + methodName + "dfg8932" + methodSig).intern();
     bsm = new MethodHandleCP(
     		MethodHandleCP.STATIC_METHOD_KIND, //bootstrap methods are always static methods 
     		bsmClassName, 

--- a/lib/jas/src/jas/MethodHandleCP.java
+++ b/lib/jas/src/jas/MethodHandleCP.java
@@ -24,7 +24,7 @@ public class MethodHandleCP extends CP implements RuntimeConstants
    */
   public MethodHandleCP(int kind, String ownerName, String fieldOrMethodName, String sig)
   {
-	uniq = kind + "$gfd¤" + ownerName + "&%$91&" + fieldOrMethodName + "*(012$" + sig;
+	uniq = kind + "$gfd\u20ac" + ownerName + "&%$91&" + fieldOrMethodName + "*(012$" + sig;
     if(kind<5) { //first for kinds refer to fields
     	fieldOrMethod = new FieldCP(ownerName, fieldOrMethodName, sig);
     } else {


### PR DESCRIPTION
In [InvokeDynamicCP.java:28](https://github.com/Sable/jasmin/blob/96accfb59e1b32eddc8e55cfcef43fa7d9c7f567/lib/jas/src/jas/InvokeDynamicCP.java#L28) and in [MethodHandleCP.java:27](https://github.com/Sable/jasmin/blob/96accfb59e1b32eddc8e55cfcef43fa7d9c7f567/lib/jas/src/jas/MethodHandleCP.java#L27) there are ISO-8559-15 characters (the € sign).

This causes warnings when I do a build on my (Linux) machine (default charset is UTF-8 here):

```
    [javac] /tmp/sableJasmin/jasmin/lib/jas/src/jas/InvokeDynamicCP.java:28: warning: unmappable character for encoding UTF8
    [javac]     uniq = (bsmClassName + "fv0�" + bsmName + "&%$91&" + bsmSig+ "*(012$" + methodName + "dfg8932" + methodSig).intern();
    [javac]                                ^
    [javac] /tmp/sableJasmin/jasmin/lib/jas/src/jas/MethodHandleCP.java:27: warning: unmappable character for encoding UTF8
    [javac]     uniq = kind + "$gfd�" + ownerName + "&%$91&" + fieldOrMethodName + "*(012$" + sig;
    [javac]                        ^
```

I suppose this is not on purpose. To solve this one of the following could be done:
1. Replace the euro sign with an escape sequence (`\u20ac`)
2. Specify `encoding="ISO-8559-15"` in the ANT-javac-Task

I'd be glad to create a pull request if you tell me which of the two it is supposed to be.
