### PR TITLE
Added ant target to publish jasmin jar files to local ivy repository.

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -1,8 +1,16 @@
 <?xml version="1.0"?>
-<project default="compile">
+<project default="compile" xmlns:ivy="antlib:org.apache.ivy.ant">
   <property file="ant.settings" />
 
   <property name="tables.dir" value="tables.out" />
+
+  <property name="ivy.install.version" value="2.1.0-rc2" />
+  <condition property="ivy.home" value="${env.IVY_HOME}">
+    <isset property="env.IVY_HOME" />
+  </condition>
+  <property name="ivy.home" value="${user.home}/.ivy2" />
+  <property name="ivy.jar.dir" value="${ivy.home}/lib" />
+  <property name="ivy.jar.file" value="${ivy.jar.dir}/ivy.jar" />
 
   <path id="jas.src">
     <pathelement location="lib/jas/src/jas" />
@@ -135,4 +143,35 @@
       <tarfileset dir="." />
     </tar>
   </target>
+
+  <!-- IVY RELATED TARGETS -->
+
+  <target name="download-ivy" unless="offline">
+
+    <mkdir dir="${ivy.jar.dir}"/>
+    <!-- download Ivy from web site so that it can be used even without any special installation -->
+    <get src="https://repo1.maven.org/maven2/org/apache/ivy/ivy/${ivy.install.version}/ivy-${ivy.install.version}.jar"
+         dest="${ivy.jar.file}" usetimestamp="true"/>
+  </target>
+
+  <target name="init-ivy" depends="download-ivy">
+    <!-- try to load ivy here from ivy home, in case the user has not already dropped
+            it into ant's lib dir (note that the latter copy will always take precedence).
+            We will not fail as long as local lib dir exists (it may be empty) and
+            ivy is in at least one of ant's lib dir or the local lib dir. -->
+    <path id="ivy.lib.path">
+      <fileset dir="${ivy.jar.dir}" includes="*.jar"/>
+
+    </path>
+    <taskdef resource="org/apache/ivy/ant/antlib.xml"
+             uri="antlib:org.apache.ivy.ant" classpathref="ivy.lib.path"/>
+  </target>
+
+  <target name="publish-local" depends="init-ivy, jasmin-fulljar, jasmin-jar, barebones">
+    <ivy:resolve/>
+    <ivy:publish pubrevision="${jasmin.version}" status="release" resolver="local" overwrite="true" >
+      <artifacts pattern="${release.loc}/[artifact]-[revision].[ext]"/>
+    </ivy:publish>
+  </target>
+
 </project>

--- a/ivy.xml
+++ b/ivy.xml
@@ -1,0 +1,10 @@
+<ivy-module version="2.0">
+    <info organisation="ca.mcgill.sable" module="jasmin"/>
+    <publications>
+        <artifact name="jasmin" type="jar" ext="jar" />
+        <artifact name="jasminsrc" type="source" ext="jar"/>
+        <!--
+        <artifact name="jasmin" type="classes" ext="jar" />
+        -->
+    </publications>
+</ivy-module>


### PR DESCRIPTION
If there is no ivy-plugin for ant installed, the ant script loads ivy.jar from maven-repo and packs it into the ant directory.