### PR TITLE
Fixed barebones task and added ant task to publish to local maven repo via ivy

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<project default="compile" xmlns:ivy="antlib:org.apache.ivy.ant">
+<project default="compile" name="jasmin" xmlns:ivy="antlib:org.apache.ivy.ant">
   <property file="ant.settings" />
 
   <property name="tables.dir" value="tables.out" />
@@ -137,10 +137,10 @@
   
   <target name="barebones" depends="clean, settings">
     <jar destfile="${release.loc}/jasminsrc-${jasmin.version}.jar">
-      <fileset dir="." />
+      <fileset dir="." excludes="${release.loc}/**" />
     </jar>
     <tar destfile="${release.loc}/jasminsrc-${jasmin.version}.tar.gz" compression="gzip" longfile="gnu">
-      <tarfileset dir="." />
+      <tarfileset dir="." excludes="${release.loc}/**" />
     </tar>
   </target>
 
@@ -166,12 +166,25 @@
     <taskdef resource="org/apache/ivy/ant/antlib.xml"
              uri="antlib:org.apache.ivy.ant" classpathref="ivy.lib.path"/>
   </target>
+	
+  <target name="gen-pom" depends="init-ivy">
+	<ivy:makepom ivyfile="ivy.xml" pomfile="${release.loc}/${ant.project.name}-${jasmin.version}.pom">
+		<mapping conf="default" scope="compile" />
+	</ivy:makepom>
+  </target>
 
-  <target name="publish-local" depends="init-ivy, jasmin-fulljar, jasmin-jar, barebones">
+  <target name="publish-local" depends="init-ivy, gen-pom, jasmin-fulljar, jasmin-jar, barebones">
     <ivy:resolve/>
     <ivy:publish pubrevision="${jasmin.version}" status="release" resolver="local" overwrite="true" >
       <artifacts pattern="${release.loc}/[artifact]-[revision].[ext]"/>
     </ivy:publish>
+  </target>
+	
+  <target name="publish-local-maven" depends="init-ivy, gen-pom, jasmin-fulljar, jasmin-jar, barebones" description="publish jar/source to maven repo mounted at ~/.m2/repository">
+		<ivy:resolve/>
+		<ivy:publish pubrevision="${jasmin.version}" resolver="local-m2-publish" forcedeliver="true" overwrite="true" publishivy="false">
+			<artifacts pattern="${release.loc}/[artifact]-[revision].[ext]" />
+		</ivy:publish>
   </target>
 
 </project>

--- a/ivy.xml
+++ b/ivy.xml
@@ -1,8 +1,15 @@
 <ivy-module version="2.0">
     <info organisation="ca.mcgill.sable" module="jasmin"/>
+    
+    <configurations>
+		<conf name="default" />
+ 		<conf name="sources" />
+	</configurations>
+	
     <publications>
-        <artifact name="jasmin" type="jar" ext="jar" />
-        <artifact name="jasminsrc" type="source" ext="jar"/>
+        <artifact name="jasmin" type="jar" ext="jar" conf="default" />
+        <artifact name="jasmin" type="pom" ext="pom" conf="default" />
+        <artifact name="jasminsrc" type="source" ext="jar" conf="sources" />
         <!--
         <artifact name="jasmin" type="classes" ext="jar" />
         -->

--- a/ivysettings.xml
+++ b/ivysettings.xml
@@ -1,0 +1,10 @@
+<ivysettings>
+  <settings defaultResolver="local"/>
+  <include url="${ivy.default.settings.dir}/ivysettings-local.xml"/>
+  <resolvers>
+    <ibiblio name="local-m2" m2compatible="true" root="file://${user.home}/.m2/repository" changingPattern=".*SNAPSHOT" />
+    <filesystem name="local-m2-publish" m2compatible="true">
+      <artifact pattern="${user.home}/.m2/repository/[organisation]/[module]/[revision]/[artifact]-[revision](-[classifier]).[ext]"/>
+    </filesystem>
+  </resolvers>
+</ivysettings>


### PR DESCRIPTION
The ant barebones failed, when release.location was inside the jasmin directory. Then <fileset dir="." />  tried to include itself.

It is now possible to publish jasmin to your local maven-repository using ant publish-local-maven