### PR TITLE
Fix NullPointerException in jasmin.Main.<clinit>

### DIFF
--- a/src/jasmin/Main.java
+++ b/src/jasmin/Main.java
@@ -61,7 +61,7 @@ public class Main {
     /**
      * The Jasmin version
      */
-    public final static String version = Main.class.getPackage().getImplementationVersion() == null ? "trunk" : Main.class.getPackage().getImplementationVersion();
+    public final static String version = Main.class.getPackage() == null || Main.class.getPackage().getImplementationVersion() == null ? "trunk" : Main.class.getPackage().getImplementationVersion();
 
     /**
      * Called to assemble a single file.


### PR DESCRIPTION
In, Java 8, getPackage() can return null and thus lead to a NullPointerException when loading the jasmin.Main class.

Fix #14 